### PR TITLE
Declaring future meetup 2

### DIFF
--- a/gen/.gitignore
+++ b/gen/.gitignore
@@ -1,0 +1,26 @@
+# This file was generated using:
+#
+#   https://github.com/trskop/snippets/blob/master/scripts/mkgitignore.sh
+#
+# and it's based on snippets taken from:
+#
+#   https://github.com/github/gitignore
+
+# {{{ Haskell.gitignore #######################################################
+dist
+cabal-dev
+*.o
+*.hi
+*.chi
+*.chs.h
+*.dyn_o
+*.dyn_hi
+.hpc
+.hsenv
+.cabal-sandbox/
+cabal.sandbox.config
+*.prof
+*.aux
+*.hp
+.stack-work/
+# }}} Haskell.gitignore #######################################################

--- a/gen/build.sh
+++ b/gen/build.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+set -e
+
+readonly -a dependencies=(
+    'blaze-html'
+    'data-default-class'
+    'iso8601-time'
+)
+readonly mainHs='test-html.hs'
+readonly indexFile='index.html'
+
+prepareSandbox()
+{
+    if [[ ! -e 'cabal.sandbox.config' ]]; then
+        cabal sandbox init
+    fi
+
+    cabal install "${dependencies[@]}"
+}
+
+buildIndex()
+{
+    local -r packageDb="$(
+        sed -nr '/^package-db:/{s/^[^:]+: *//;p}' cabal.sandbox.config
+    )"
+
+    runhaskell -package-db="$packageDb" "$mainHs"
+}
+
+checkExitCode()
+{
+    if (( $# )); then
+        local -r -i isFinal="$1"; shift
+    else
+        local -r -i isFinal=0
+    fi
+
+    if (( ret )); then
+        printf '\n\n*** FAILED: exit code: %n\n' $ret
+        exit $ret
+    else
+        if (( isFinal )); then
+            printf '\n*** SUCCESS\n'
+        fi
+    fi
+}
+
+main()
+{
+    local ret=0
+
+    printf '*** Checking if "%s" is available:\n\n' "$mainHs"
+    if [[ -e "$mainHs" ]]; then
+        echo "$mainHs: File found."
+    else
+        ret=1
+        echo "$mainHs: File NOT found: Are we running from correct directory?"
+    fi
+    checkExitCode
+
+    printf '\n*** Preparing cabal sandbox and installing dependencies:\n\n'
+    prepareSandbox || ret=$?
+    checkExitCode
+
+    printf '\n*** Building new "%s":\n\n' "$indexFile"
+    buildIndex || ret=$?
+    if (( ret == 0 )); then
+        if [[ -e "$indexFile" ]]; then
+            echo "$indexFile: New index file. Please move it to correct place."
+        else
+            echo "Error: $indexFile: Something went wrong and file is missing."
+        fi
+    fi
+
+    local -r FINAL_CHECK=1
+    checkExitCode FINAL_CHECK
+
+    exit $ret
+}
+
+main "$@"

--- a/gen/build.sh
+++ b/gen/build.sh
@@ -37,7 +37,7 @@ checkExitCode()
     fi
 
     if (( ret )); then
-        printf '\n\n*** FAILED: exit code: %n\n' $ret
+        printf '\n\n*** FAILED: exit code: %d\n' $ret
         exit $ret
     else
         if (( isFinal )); then

--- a/gen/test-html.hs
+++ b/gen/test-html.hs
@@ -6,6 +6,7 @@ import qualified Text.Blaze.Html5 as H
 import qualified Text.Blaze.Html5.Attributes as A
 -- import qualified Text.Blaze.Html.Renderer.Pretty as R
 
+import Data.Default.Class (Default(def))
 import Data.List (intercalate)
 import Data.Monoid
 import Data.Time
@@ -30,6 +31,16 @@ data Presentation = Presentation
     -- presentation.
     } deriving Show
 
+instance Default Presentation where
+    def = Presentation
+        { title = "Unknown title"
+        , author = "Unknown author"
+        , tags = []
+        , slides = Nothing
+        , audio = Nothing
+        , player = Nothing
+        }
+
 data Meetup = Meetup
     { indexM :: Integer
     -- ^ Meetups form a total order in time and is mapped in to linear ordering
@@ -43,14 +54,26 @@ data Meetup = Meetup
     -- this is set, obviously, to 'Nothing'.
     } deriving Show
 
+instance Default Meetup where
+    def = Meetup
+        { indexM = -1
+        , presentations = []
+        , time = Nothing
+        , participants = Nothing
+        }
+
+-- | Assign index to a 'Meetup'. It expects them to be in reverse order, i.e.
+-- newest/future first and oldest as last.
+indexMeetups :: [Meetup] -> [Meetup]
+indexMeetups = reverse . zipWith (\idx m -> m{indexM = idx}) [0..] . reverse
+
 -- | List of all meetups, those that already occurred and those that are
 -- planned. Meetups are ordered from newest/future down to the oldes; so please
 -- add new meetups on top.
 meetups :: [Meetup]
-meetups =
-    [ Meetup
-        { indexM = 1
-        , presentations =
+meetups = indexMeetups
+    [ def
+        { presentations =
             [ Presentation
                 { title = "Apples and Oranges"
                 , author = "Matej"
@@ -63,9 +86,8 @@ meetups =
         , time = Just $ read "2015-05-12 18:00:00 +02:00"
         , participants = Just $ 4 + 18
         }
-    , Meetup
-        { indexM = 0
-        , presentations =
+    , def
+        { presentations =
             [ Presentation
                 { title = "There Is No Compiler"
                 , author = "Matej"

--- a/gen/test-html.hs
+++ b/gen/test-html.hs
@@ -21,18 +21,31 @@ data Presentation = Presentation
     { title :: String
     , author :: String
     , tags :: [Tag]
-    , slides :: Maybe String
-    , audio :: Maybe String
-    , player :: Maybe String
+    , slides :: Maybe FilePath
+    -- ^ Relative path to slides.
+    , audio :: Maybe FilePath
+    -- ^ Relative path to audio recording of this presentation.
+    , player :: Maybe FilePath
+    -- ^ Relative path to web player able to handle audio recording of this
+    -- presentation.
     } deriving Show
 
 data Meetup = Meetup
     { indexM :: Integer
+    -- ^ Meetups form a total order in time and is mapped in to linear ordering
+    -- of 'Integer' numbers starting from 0.
     , presentations :: [Presentation]
+    -- ^ List of presentations presented during meetup.
     , time :: Maybe ZonedTime
+    -- ^ Time when the meetup occurred
     , participants :: Maybe Integer
+    -- ^ Number of participats, for future, or meetups currently being held,
+    -- this is set, obviously, to 'Nothing'.
     } deriving Show
 
+-- | List of all meetups, those that already occurred and those that are
+-- planned. Meetups are ordered from newest/future down to the oldes; so please
+-- add new meetups on top.
 meetups :: [Meetup]
 meetups =
     [ Meetup

--- a/gen/test-html.hs
+++ b/gen/test-html.hs
@@ -74,6 +74,16 @@ meetups :: [Meetup]
 meetups = indexMeetups
     [ def
         { presentations =
+            [ def
+                { title =
+                    "Types as values: Derive correctness from practicality"
+                , author = "Peter"
+                , tags = [Haskell, Types]
+                }
+            ]
+        }
+    , def
+        { presentations =
             [ Presentation
                 { title = "Apples and Oranges"
                 , author = "Matej"

--- a/gen/test-html.hs
+++ b/gen/test-html.hs
@@ -18,17 +18,21 @@ data Tag
     | Types
     deriving Show
 
+type URL = String
+
 data Presentation = Presentation
     { title :: String
     , author :: String
     , tags :: [Tag]
-    , slides :: Maybe FilePath
-    -- ^ Relative path to slides.
-    , audio :: Maybe FilePath
-    -- ^ Relative path to audio recording of this presentation.
-    , player :: Maybe FilePath
-    -- ^ Relative path to web player able to handle audio recording of this
-    -- presentation.
+    , slides :: Maybe URL
+    -- ^ URL to slides of this presentation. 'Nothing' in case that there are
+    -- no slides.
+    , audio :: Maybe URL
+    -- ^ URL to audio recording of this presentation or 'Nothing' if there is
+    -- not any recording.
+    , player :: Maybe URL
+    -- ^ URL to web player able to handle audio recording of this presentation.
+    -- Set to 'Nothing' in case that wab player is not provided.
     } deriving Show
 
 instance Default Presentation where


### PR DESCRIPTION
Declared future meetup 2 with presentation named "Types as values: Derive correctness from practicality".

While trying to understand the code I've made some notes and they were the basis for Haddock comments that are included in this pull request.

To simplify insertion of future meetups and to automatically generate meetup indexes, I've created default values for both Meetup and Presentation data types.

New "index.html" is not part of this pull request. I want to be sure that it will be accepted before doing so.
